### PR TITLE
Fix EMEA Link

### DIFF
--- a/resources/lang/de/landing.php
+++ b/resources/lang/de/landing.php
@@ -42,7 +42,7 @@ return array (
             </h1>
             <p class="sub">Auf diesen Seiten findest du alle notwendigen Informationen um in der vACC Germany zu lotsen oder zu fliegen.</p>
 						<p class="pb-20">
-							VATSIM Germany ist Mitglied in der <b><a href="https://www.vateud.net" target="_blank">VATSIM Europe Division</a></b>, die wiederum mit weiteren Divisions die <b><a href="https://www.vatsim.eu/" target="_blank">VATSIM Europe, Middle East and Africa Region</a></b> bildet. Insgesamt sind sie Teil des globalen <a href="https://www.vatsim.net" target="_blank"><b>VATSIM</b></a>-Netzwerks, das Piloten, die mit ihrem Flugsimulator an dieses Netzwerk angeschlossen sind, ATC-Dienste über das Internet kostenlos zur Verfügung stellt.
+							VATSIM Germany ist Mitglied in der <b><a href="https://www.vateud.net" target="_blank">VATSIM Europe Division</a></b>, die wiederum mit weiteren Divisions die <b><a href="https://vatsim.net/docs/regions/emea" target="_blank">VATSIM Europe, Middle East and Africa Region</a></b> bildet. Insgesamt sind sie Teil des globalen <a href="https://www.vatsim.net" target="_blank"><b>VATSIM</b></a>-Netzwerks, das Piloten, die mit ihrem Flugsimulator an dieses Netzwerk angeschlossen sind, ATC-Dienste über das Internet kostenlos zur Verfügung stellt.
             </p>
             <p>Viel Spaß im virtuellen deutschen Luftraum</p>
             <p>Euer VATSIM Germany Staff</p>',

--- a/resources/lang/en/landing.php
+++ b/resources/lang/en/landing.php
@@ -39,7 +39,7 @@ return array (
   'welcome' => '<h6>The vACC for Germany on the VATSIM network.</h6>
     <h1>Welcome to VATSIM Germany</h1>
     <p class="sub">On these pages you will find information on how to become a controller within our vACC, as well as about flying within vACC Germany\'s area.</p>
-    <p class="pb-20">VATSIM Germany is part of the <a href="https://www.vateud.net" target="_blank"><b>VATSIM Europe Division</b></a>, which together with other divisions forms the <a href="https://www.vatsim.eu/" target="_blank"><b>VATSIM Europe, Middle East and Africa Region</b></a>. Altogether they are a part of the global <a href="https://www.vatsim.net" target="_blank"><b>VATSIM</b></a> network, which provides ATC services over the internet free of charge to pilots connected to this network using their flight simulator.</p>
+    <p class="pb-20">VATSIM Germany is part of the <a href="https://www.vateud.net" target="_blank"><b>VATSIM Europe Division</b></a>, which together with other divisions forms the <a href="https://vatsim.net/docs/regions/emea" target="_blank"><b>VATSIM Europe, Middle East and Africa Region</b></a>. Altogether they are a part of the global <a href="https://www.vatsim.net" target="_blank"><b>VATSIM</b></a> network, which provides ATC services over the internet free of charge to pilots connected to this network using their flight simulator.</p>
     <p>Enjoy your stay in German airspace!</p>
     <p>Your Staff of VATSIM Germany</p>',
 );


### PR DESCRIPTION
https://vatsim.eu no longer exists. Instead, replaced with https://vatsim.net/docs/regions/emea