### PR TITLE
Fix training type for VATSIM Booking API

### DIFF
--- a/app/Libraries/ATCBookingsApi.php
+++ b/app/Libraries/ATCBookingsApi.php
@@ -19,7 +19,7 @@ class ATCBookingsApi
             $type = 'event';
         }
         if ($booking->training) {
-            $type = 'mentoring';
+            $type = 'training';
         }
         //if ($booking->exam) {
         //    $type = 'exam';


### PR DESCRIPTION
- Change from 'mentoring' -> 'training' (Documentation is incorrect).

The documentation states that 'mentoring' is used as the type. This is however, after confirmation from VATSIM tech, incorrect. The correct type should be 'training'. 